### PR TITLE
Disable SSL v3, close POODLE vulnerability

### DIFF
--- a/roles/nginx/templates/youtubeadl.j2
+++ b/roles/nginx/templates/youtubeadl.j2
@@ -15,9 +15,10 @@ server {
 server {
     listen              443;
     server_name         {{ nginx_server_name }};
-	ssl on;
-	ssl_certificate     {{ ssl_dest_dir }}/{{ application_name }}.crt;
-	ssl_certificate_key {{ ssl_dest_dir }}/{{ application_name }}.key;
+    ssl on;
+    ssl_certificate     {{ ssl_dest_dir }}/{{ application_name }}.crt;
+    ssl_certificate_key {{ ssl_dest_dir }}/{{ application_name }}.key;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
 
     client_max_body_size 4G;
 


### PR DESCRIPTION
SSL v3 has a widely known vulnerability in the protocol. For security reasons, [it should be disabled](http://disablessl3.com/#nginx).

While we're at it, remove the only tabs remaining in the NGINX config file.