### PR TITLE
Remove erroneous usage of default(omit)

### DIFF
--- a/roles/web/vars/main.yml
+++ b/roles/web/vars/main.yml
@@ -28,7 +28,4 @@ django_environment:
   STATIC_ROOT: "{{ nginx_static_dir }}"
   DATABASE_USER: "{{ db_user }}"
   DATABASE_PASSWORD: "{{ db_password }}"
-  EMAIL_HOST: "{{ email_host|default(omit) }}"
-  EMAIL_HOST_USER: "{{ email_host_user|default(omit) }}"
-  EMAIL_HOST_PASSWORD: "{{ email_host_password|default(omit) }}"
-  BROKER_URL: "{{ broker_url|default(omit) }}"
+  BROKER_URL: "{{ broker_url }}"


### PR DESCRIPTION
Unfortunately, `default(omit)` "is a hack that applies only to the arguments passed to a module." (https://github.com/ansible/ansible/issues/14130)

This pattern creates problems for the postactivate script as well as any usage of `environment: "{{ django_environment }}"` as any omitted variables will be set to `"__omit_place_holder__<token>"`

This pattern doesn't currently create any problems since all the key Django environment variables are defined. However, if one were to copy this pattern (say, for creating additional optional Django environment vars) or rely on any omitted environment variables to not be set, you'd have an unexpected result.

----

```bash
vagrant up
vagrant ssh
sudo cat /webapps/youtubeadl/bin/postactivate
#!/bin/sh

export EMAIL_HOST_PASSWORD="__omit_place_holder__05e91510b2a8eaa87af350f16cb45ebaf41346e1"
export STATIC_ROOT="/webapps/youtubeadl/static/"
...
export EMAIL_HOST_USER="__omit_place_holder__05e91510b2a8eaa87af350f16cb45ebaf41346e1"
export EMAIL_HOST="__omit_place_holder__05e91510b2a8eaa87af350f16cb45ebaf41346e1"
```

