### PR TITLE
Enable ssh agent forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ A cron job to automatically renew the certificate will run daily.  Note that if 
 
 - Make sure `ssh-agent` is running on your local machine.
 - Enable `ForwardAgent` on your machine's SSH config file, for example:
-    Host example.com
+    Host example.com  # Must be your fqdn for `{{ inventory_hostname }}` variable to be set correctly
         IdentityFile ~/.ssh/id_rsa
         user root
         IdentitiesOnly yes

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ A cron job to automatically renew the certificate will run daily.  Note that if 
 
 **Requirements:**
 
-- Make sure `ssh-agent` is running on your local machine.
+- Make sure ssh-agent is running on your local machine (run `ssh-agent` from the command line)
+- Test that your ssh key is ready for forwarding via `ssh-add -L`; if not, add your key (`ssh-add yourkey`)
 - Enable `ForwardAgent` on your machine's SSH config file, for example:
 ```
 Host example.com  # Must be your fqdn for `{{ inventory_hostname }}` variable to be set correctly
@@ -256,7 +257,7 @@ Host example.com  # Must be your fqdn for `{{ inventory_hostname }}` variable to
 ```
 - Make sure you're using the SSH connection to your repo (not the HTTPS connection)
 - Ensure that your domain (e.g., `example.com`) points to your server's IP address
-- Refer to the Github tutorial in the useful links section for help debugging SSH agent forwarding 
+- Refer to the [Github tutorial](https://developer.github.com/guides/using-ssh-agent-forwarding/) for help debugging SSH agent forwarding 
 
 
 ## Useful Links

--- a/README.md
+++ b/README.md
@@ -247,11 +247,13 @@ A cron job to automatically renew the certificate will run daily.  Note that if 
 
 - Make sure `ssh-agent` is running on your local machine.
 - Enable `ForwardAgent` on your machine's SSH config file, for example:
-    Host example.com  # Must be your fqdn for `{{ inventory_hostname }}` variable to be set correctly
-        IdentityFile ~/.ssh/id_rsa
-        user root
-        IdentitiesOnly yes
-        ForwardAgent yes
+```
+Host example.com  # Must be your fqdn for `{{ inventory_hostname }}` variable to be set correctly
+    IdentityFile ~/.ssh/id_rsa
+    user root
+    IdentitiesOnly yes
+    ForwardAgent yes
+```
 - Make sure you're using the SSH connection to your repo (not the HTTPS connection)
 - Ensure that your domain (e.g., `example.com`) points to your server's IP address
 - Refer to the Github tutorial in the useful links section for help debugging SSH agent forwarding 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A cron job to automatically renew the certificate will run daily.  Note that if 
         user root
         IdentitiesOnly yes
         ForwardAgent yes
+- Make sure you're using the SSH connection to your repo (not the HTTPS connection)
 - Ensure that your domain (e.g., `example.com`) points to your server's IP address
 - Refer to the Github tutorial in the useful links section for help debugging SSH agent forwarding 
 

--- a/README.md
+++ b/README.md
@@ -241,9 +241,25 @@ In `roles/certbot/defaults/main.yml`, you may want to override the `certbot_admi
 
 A cron job to automatically renew the certificate will run daily.  Note that if a certificate is due for renewal (expiring in less than 30 days), Nginx will be stopped before the certificate can be renewed and then started again once renewal is finished.  Otherwise, nothing will happen so it's safe to leave it running daily.
 
+### Pulling from a private git repository using SSH agent forwarding
+
+**Requirements:**
+
+- Make sure `ssh-agent` is running on your local machine.
+- Enable `ForwardAgent` on your machine's SSH config file, for example:
+    Host example.com
+        IdentityFile ~/.ssh/id_rsa
+        user root
+        IdentitiesOnly yes
+        ForwardAgent yes
+- Ensure that your domain (e.g., `example.com`) points to your server's IP address
+- Refer to the Github tutorial in the useful links section for help debugging SSH agent forwarding 
+
+
 ## Useful Links
 
 - [Ansible - Getting Started](http://docs.ansible.com/intro_getting_started.html)
 - [Ansible - Best Practices](http://docs.ansible.com/playbooks_best_practices.html)
 - [Setting up Django with Nginx, Gunicorn, virtualenv, supervisor and PostgreSQL](http://michal.karzynski.pl/blog/2013/06/09/django-nginx-gunicorn-virtualenv-supervisor/)
 - [How to deploy encrypted copies of your SSL keys and other files with Ansible and OpenSSL](http://www.calazan.com/how-to-deploy-encrypted-copies-of-your-ssl-keys-and-other-files-with-ansible-and-openssl/)
+- [Using SSH agent forwarding - GitHub developer guide](https://developer.github.com/guides/using-ssh-agent-forwarding/)

--- a/env_vars/base.yml
+++ b/env_vars/base.yml
@@ -1,6 +1,6 @@
 ---
 
-git_repo: https://github.com/jcalazan/youtube-audio-dl.git
+git_repo: git@github.com:jcalazan/youtube-audio-dl.git
 
 project_name: youtube-audio-dl
 application_name: youtubeadl

--- a/roles/web/defaults/main.yml
+++ b/roles/web/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
 
 virtualenv_python_version: python2.7
+
+ssh_known_hosts_command: "ssh-keyscan -H -T 10"
+ssh_known_hosts_file: "/etc/ssh/ssh_known_hosts"
+ssh_known_hosts:
+  - github.com

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -3,6 +3,8 @@
 - include: install_additional_packages.yml
   tags: packages
 
+- include: setup_known_hosts.yml
+
 - include: create_users_and_groups.yml
 
 - include: set_file_permissions.yml

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -5,10 +5,14 @@
 
 - include: create_users_and_groups.yml
 
+- include: set_file_permissions.yml
+  tags: deploy
+
 - include: setup_virtualenv.yml
   tags: virtualenv
 
 - include: setup_git_repo.yml
+  become: no
   tags: deploy
 
 - include: setup_django_app.yml
@@ -16,6 +20,3 @@
 
 - include: setup_supervisor.yml
   tags: supervisor
-
-- include: set_file_permissions.yml
-  tags: deploy

--- a/roles/web/tasks/setup_django_app.yml
+++ b/roles/web/tasks/setup_django_app.yml
@@ -31,4 +31,7 @@
     settings: "{{ django_settings_file }}"
   environment: "{{ django_environment }}"
   when: run_django_collectstatic is defined and run_django_collectstatic
-  tags: django.collectstatic
+  become: no
+  tags: 
+    - django.collectstatic
+    - deploy

--- a/roles/web/tasks/setup_known_hosts.yml
+++ b/roles/web/tasks/setup_known_hosts.yml
@@ -1,0 +1,13 @@
+- name: Make sure the known hosts file exists
+  file: "path={{ ssh_known_hosts_file }} state=touch"
+
+- name: Check host name availability
+  shell: "ssh-keygen -f {{ ssh_known_hosts_file }} -F {{ item }}"
+  with_items: "{{ ssh_known_hosts }}"
+  register: ssh_known_host_results
+  ignore_errors: yes
+
+- name: Scan the public key
+  shell: "{{ ssh_known_hosts_command}} {{ item.item }} >> {{ ssh_known_hosts_file }}"
+  with_items: "{{ ssh_known_host_results.results }}"
+  when: item.stdout == ""


### PR DESCRIPTION
Resolves #11 

This PR adjusts the playbook to allow SSH agent forwarding and explains how to do this in the README. Tested on Ubuntu 14.04

The main changes are:
- Use the GitHub SSH connection rather than the HTTP connection.
- SSH forwarding can't be done as a sudo user, therefore this sets `become: no` on the `setup_git_repo` task and moves `set_file_permissions` before setting up the git repo so that a non-sudo user can execute the task
- Add README describing how to setup SSH Forwarding

Let me know if any questions or improvements?
