### PR TITLE
Use items() to support both python2 and python3

### DIFF
--- a/roles/web/templates/virtualenv_postactivate.j2
+++ b/roles/web/templates/virtualenv_postactivate.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-{% for variable_name, value in django_environment.iteritems() %}
+{% for variable_name, value in django_environment.items() %}
 export {{ variable_name }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
python3 does not support iteritems() on dict. I was unable to do six.iteritems(django_environment) but was unable to do it in J2 template. This allows playbook to be played with both python2 and python3.