### PR TITLE
Remove notify from tasks where changed_when is False; add restart application handler to changes in git repo and collectstatic command.

### DIFF
--- a/roles/security/tasks/create_non_root_sudo_user.yml
+++ b/roles/security/tasks/create_non_root_sudo_user.yml
@@ -27,6 +27,5 @@
 
 - name: Delete root password
   action: shell passwd -d root
-  notify: restart ssh
   tags: skip_ansible_lint
   changed_when: False

--- a/roles/web/tasks/set_file_permissions.yml
+++ b/roles/web/tasks/set_file_permissions.yml
@@ -7,4 +7,3 @@
         group={{ gunicorn_group }}
         state=directory
   changed_when: False
-  notify: restart application

--- a/roles/web/tasks/setup_django_app.yml
+++ b/roles/web/tasks/setup_django_app.yml
@@ -31,4 +31,5 @@
     settings: "{{ django_settings_file }}"
   environment: "{{ django_environment }}"
   when: run_django_collectstatic is defined and run_django_collectstatic
+  notify: restart application
   tags: django.collectstatic

--- a/roles/web/tasks/setup_git_repo.yml
+++ b/roles/web/tasks/setup_git_repo.yml
@@ -6,6 +6,7 @@
        dest={{ project_path }}
        accept_hostkey=yes
   when: setup_git_repo is defined and setup_git_repo
+  notify: restart application
   tags: git
 
 - name: Delete all .pyc files


### PR DESCRIPTION
In parts of the repo we have `changed_when: False` to make sure the test suite doesn't throw an error in its idempotence test. However, if `changed_when` is set to false, `notify` will never run. 

The issue I was experiencing is that the `restart application` handler is being called from `set_file_premissions.yml`, so running tasks with the `deploy` tag wasn't triggering Supervisor to restart the Gunicorn app.

This PR removes any `notify` directive from tasks that have `changed_when: False`. It also moves the `restart application` handler to run after changes occur to the git repo or collectstatic tasks (which makes more sense anyway because these are actual signs that the app needs restarting).