### PR TITLE
Encrypt database user password to support PostgreSQL 10.

### DIFF
--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -39,6 +39,7 @@
   postgresql_user: db={{ db_name }}
                    name={{ db_user }}
                    password={{ db_password }}
+                   encrypted=yes
                    priv=ALL
                    state=present
 


### PR DESCRIPTION
This adds the `enctyped=yes` directive that is now required for PostgreSQL 10. It should be backwards compatible for any Postgres instance <= 9.2 and probably earlier. 

Per the [release notes](https://www.postgresql.org/docs/devel/static/release-10.html): 

> Remove the ability to store unencrypted passwords on the server (Heikki Linnakangas)

> The password_encryption server parameter no longer supports off or plain. The UNENCRYPTED option is no longer supported in CREATE/ALTER USER ... PASSSWORD. Similarly, the --unencrypted option has been removed from createuser. Unencrypted passwords migrated from older versions will be stored encrypted in this release. The default setting for password_encryption is still md5.