### PR TITLE
Checkout code from private git repositories using ssh agent forwarding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,34 @@ vagrant reload
 vagrant halt
 ```
 
-## Private Repositories
+## Pulling from a private git repository using SSH agent forwarding
 
-If your code is in a private repository then you need some way of authenticating
-yourself during the deployment. If you add a public SSH key to the git server
-then you can use SSH agent forwarding so the request to unlock the key so the
-code can be checked out is forwarded to the machine where you run the playbook.
+If your code is in a private repository you must use an SSH connection along
+with a key so ansible can checkout the code. HTTPS connections and SSH 
+connections with a username and password do not work because ansible cannot 
+deal with interactive logins.
 
-The first thing you need to do is set the ssh_agent_forwarding flag in
+Using SSH agent forwarding we can get the authentication request from the 
+repository sent to the machine where the playbook is run. That keeps the 
+private key to the repository as safe as possible. To set this up you need to:
+
+- Add a public key to the server hosting your repo. 
+- Make sure ssh-agent is running on your local machine
+- Add the public key to ssh-agent
+
+[Connecting to GitHub with SSH](https://help.github.com/articles/connecting-to-github-with-ssh/) 
+has all the information on key generation, adding keys to the server, setting up ssh-agent and
+troubleshooting any problems.
+
+Your server SSH configuration should work out-of-the-box. The "Server-Side 
+Configuration Options" section in [SSH Essentials: Working with SSH Servers, Clients, and
+Keys](https://www.digitalocean.com/community/tutorials/ssh-essentials-working-with-ssh-servers-clients-and-keys)
+has good advice on locking down who can access the server over SSH
+connections.
+
+### Getting the playbook to use agent forwarding
+
+The first thing you need to do is set the ssh_agent_forwarding flag in 
 env_vars/base.yml to `true`:
 ```
 ssh_forward_agent: true
@@ -160,8 +180,8 @@ This flag is used when configuring sudoers so that any user you become on the
 remote server will also use the same socket connection when requesting to
 unlock keys.
 
-To enable SSH agent forwarding on the Vagrant box, change the following flag and
-set it to `true`:
+To enable SSH agent forwarding on the Vagrant box, change the following flag in
+VagrantFile and set it to `true`:
 ```
 config.ssh.forward_agent = true
 ```
@@ -174,6 +194,9 @@ ansible-playbook --ssh-extra-args=-A -i production site.yml
 
 This is a little bit clunky but it does not restrict you from setting other
 SSH options if you need to.
+
+
+
 
 ## Security
 
@@ -374,6 +397,7 @@ running daily.
 - [Ansible - Best Practices][ansible-best_practices]
 - [Setting up Django with Nginx, Gunicorn, virtualenv, supervisor and PostgreSQL][michal-ansible_guide]
 - [How to deploy encrypted copies of your SSL keys and other files with Ansible and OpenSSL][deploy-encrypted-copies]
+- [Using SSH agent forwarding - GitHub developer guide](https://developer.github.com/guides/using-ssh-agent-forwarding/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,38 @@ vagrant reload
 vagrant halt
 ```
 
+## Private Repositories
+
+If your code is in a private repository then you need some way of authenticating
+yourself during the deployment. If you add a public SSH key to the git server
+then you can use SSH agent forwarding so the request to unlock the key so the
+code can be checked out is forwarded to the machine where you run the playbook.
+
+The first thing you need to do is set the ssh_agent_forwarding flag in
+env_vars/base.yml to `true`:
+```
+ssh_forward_agent: true
+```
+
+This flag is used when configuring sudoers so that any user you become on the
+remote server will also use the same socket connection when requesting to
+unlock keys.
+
+To enable SSH agent forwarding on the Vagrant box, change the following flag and
+set it to `true`:
+```
+config.ssh.forward_agent = true
+```
+
+When running a playbook to provision a server, you enable SSH agent forwarding
+using the `--ssh-extra-args` option on the command line:
+```
+ansible-playbook --ssh-extra-args=-A -i production site.yml
+```
+
+This is a little bit clunky but it does not restrict you from setting other
+SSH options if you need to.
+
 ## Security
 
 *NOTE: Do not run the Security role without understanding what it does.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
+  config.ssh.forward_agent = false
 
   config.vm.define "my-cool-app.local", primary: true do |app|
     app.vm.hostname = "my-cool-app"

--- a/env_vars/base.yml
+++ b/env_vars/base.yml
@@ -2,6 +2,10 @@
 
 git_repo: https://github.com/jcalazan/youtube-audio-dl.git
 
+# Set this flag to true so you can checkout code from a private git repository
+# which is setup with an SSH key.
+ssh_forward_agent: false
+
 project_name: youtube-audio-dl
 application_name: youtubeadl
 

--- a/roles/web/tasks/setup_git_repo.yml
+++ b/roles/web/tasks/setup_git_repo.yml
@@ -28,7 +28,7 @@
 
 - name: Setup the Git repo
   environment:
-      TMPDIR: "/var/tmp"
+    TMPDIR: "/var/tmp"
   git: repo={{ git_repo }}
        version={{ git_branch }}
        dest={{ project_path }}

--- a/roles/web/tasks/setup_git_repo.yml
+++ b/roles/web/tasks/setup_git_repo.yml
@@ -1,6 +1,34 @@
 ---
 
+# Make sure the sudoers file preserves the ability to use ssh forwarding.
+# That way we don't need to store a private key on the server to get
+# access to the git repository. Don't forget to add the key used by the
+# git repository to your ssh-agent using ssh-add on the machine where you
+# run the playbooks.
+#
+# https://stackoverflow.com/questions/24124140/ssh-agent-forwarding-with-ansible
+
+- name: Add ssh agent line to sudoers
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: SSH_AUTH_SOCK
+    line: Defaults env_keep += "SSH_AUTH_SOCK"
+  when: ssh_forward_agent is defined and ssh_forward_agent
+  tags: git
+
+# The git module calls python's tempfile.mkstemp() which uses the TMPDIR
+# environment variable. However this is set to /tmp which is mounted as
+# noexec. As a result the git command will fail. The solution is to set
+# TMPDIR to point to some other suitable location. Here we use /var/tmp
+# but any suitable location will do.
+#
+# https://github.com/ansible/ansible/issues/30064
+# https://docs.python.org/dev/library/tempfile.html?highlight=mkstemp#tempfile.tempdir
+
 - name: Setup the Git repo
+  environment:
+      TMPDIR: "/var/tmp"
   git: repo={{ git_repo }}
        version={{ git_branch }}
        dest={{ project_path }}


### PR DESCRIPTION
Currently when using the playbook with a private repository the easiest
way to do it is to copy the private key to the remote server. This is
extremely dangerous. If you lose control of the server then you have lost
control of your source code. In any reasonably busy project tracking down
changes from a malicious user will be very difficult indeed.

The solution is to enable SSH agent forwarding on the remote server (and
the Vagrant box) so when the code is checked out from a git repository,
to which an SSH public key has been added, the request to unlock the key
will be forwarded to the control node where the playbook (or Vagrant)
is being run.

Enabling SSH agent forwarding is simple. Vagrant supports it using the
configuration flag, config.ssh.forward_agent. Ansible also supports it
through the --extra-ssh-args which can be specified on the command line
when the playbook is run. You could also set it in ansible.cfg or as the
ansible_ssh_extra_args variable which could be set in the inventory or
playbook files. The command line option was chosen since it is the simplest
and does not interfere with any other options the user might want to set.

There were two complications when getting forwarding to work on the remote
server:

1. The git command is run as a separate process and so as a separate user.
   That meant the socket connection set up to forward the key unlock
   request was "lost". The solution was to add a task to preserve the
   SSH_AUTH_SOCK environment variable when the git module is run so it
   can still access forwarded ports. The task is conditional on the
   variables, setup_git_repo and ssh_forward_agent and the git tag was
   added so it only runs when git is being configured.

2. The ansible git module uses python's tempfile.mkstemp() which in turn
   uses tempfile.tempdir. The value is taken from the environment variable
   TMPDIR, and typically is set to /tmp. Unfortunately /tmp is mounted as
   noexec and so the command fails. The solution is to redefine the value
   of TMPDIR for the task to somethis with exec privileges, in this case
   /var/tmp, so the command can complete.

 The changes were made to roles/web/tasks/setup_git_repo.yml and are
 fully commented with linked to the issues so the rationle for the changes
 are clear to users.

This was tested using Vagrant and a basic size droplet from Digital Ocean.