### PR TITLE
Use state=present (state=installed is deprecated)

### DIFF
--- a/roles/avahi/tasks/main.yml
+++ b/roles/avahi/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install the Avahi mDNS/DNS-SD daemon
-  apt: name=avahi-daemon update_cache={{ update_apt_cache }} state=installed
+  apt: name=avahi-daemon update_cache={{ update_apt_cache }} state=present
   tags: packages
 
 - name: Ensure the Avahi mDNS/DNS-SD daemon is running

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -13,7 +13,7 @@
     - skip_ansible_lint
 
 - name: Install base packages
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=installed
+  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
   with_items:
     - locales
     - build-essential

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -13,7 +13,7 @@
   locale_gen: name=en_US.UTF-8
 
 - name: Install PostgreSQL
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=installed
+  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
   with_items:
     - postgresql
     - postgresql-contrib

--- a/roles/memcached/tasks/main.yml
+++ b/roles/memcached/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Memcached
-  apt: name=memcached update_cache={{ update_apt_cache }} state=installed
+  apt: name=memcached update_cache={{ update_apt_cache }} state=present
   tags: packages
 
 - name: Create the Memcached configuration file

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Nginx
-  apt: name=nginx update_cache={{ update_apt_cache }} state=installed
+  apt: name=nginx update_cache={{ update_apt_cache }} state=present
   tags: packages
 
 - name: Copy the SSL certificate to the remote server

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -10,7 +10,7 @@
                   state=present
 
 - name: Install RabbitMQ server
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=installed
+  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
   with_items:
     - rabbitmq-server
 

--- a/roles/security/tasks/setup_fail2ban.yml
+++ b/roles/security/tasks/setup_fail2ban.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install fail2ban
-  apt: update_cache={{ update_apt_cache }} state=installed pkg=fail2ban
+  apt: update_cache={{ update_apt_cache }} state=present pkg=fail2ban
 
 - name: Set up fail2ban
   command: cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local

--- a/roles/security/tasks/setup_unattended_upgrades.yml
+++ b/roles/security/tasks/setup_unattended_upgrades.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Unattended Upgrades
-  apt: update_cache={{ update_apt_cache }} state=installed pkg=unattended-upgrades
+  apt: update_cache={{ update_apt_cache }} state=present pkg=unattended-upgrades
 
 - name: Set up unattended upgrades
   copy: src=apt_periodic dest=/etc/apt/apt.conf.d/10periodic

--- a/roles/security/tasks/setup_uncomplicated_firewall.yml
+++ b/roles/security/tasks/setup_uncomplicated_firewall.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install Uncomplicated Firewall
-  apt: update_cache={{ update_apt_cache }} state=installed pkg=ufw
+  apt: update_cache={{ update_apt_cache }} state=present pkg=ufw
 
   # Allow only ssh and http(s) ports
 - name: Allow ssh and http(s) connections

--- a/roles/web/tasks/install_additional_packages.yml
+++ b/roles/web/tasks/install_additional_packages.yml
@@ -7,7 +7,7 @@
   when: enable_deadsnakes_ppa
 
 - name: Install additional packages
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=installed
+  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
   with_items:
     - libcurl4-gnutls-dev
     - gnutls-dev


### PR DESCRIPTION
`state=present` has been the preferred syntax [since at least Ansible version 2.3](https://docs.ansible.com/ansible/2.3/apt_module.html).

From what I can tell, `state=present` _should_ be supported in `apt` for Ansible 2.2 as well (although, is that version still officially supported by this project?)

From [2.2 docs](https://media.readthedocs.org/pdf/ansible/latest/ansible.pdf):
> The `state`parameter is optional to a lot of modules.  Whether `state=present` or `state=absent`, it’s always best to leave that parameter in your playbooks to make it clear, especially as some modules support additional states.


As of version 2.5, it's officially deprecated (to be removed in version 2.9).