### PR TITLE
Don't loop over `apt` or `pip` packages

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -13,17 +13,19 @@
     - skip_ansible_lint
 
 - name: Install base packages
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
-  with_items:
-    - locales
-    - build-essential
-    - acl
-    - ntp
-    - htop
-    - git
-    - "{{ base_python_package }}-pip"
-    - "i{{ base_python_package }}"
-    - supervisor
+  apt:
+    update_cache: "{{ update_apt_cache }}"
+    state: present
+    name:
+      - locales
+      - build-essential
+      - acl
+      - ntp
+      - htop
+      - git
+      - "{{ base_python_package }}-pip"
+      - "i{{ base_python_package }}"
+      - supervisor
   tags:
     - packages
     - packages.security

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -13,11 +13,13 @@
   locale_gen: name=en_US.UTF-8
 
 - name: Install PostgreSQL
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
-  with_items:
-    - postgresql
-    - postgresql-contrib
-    - "{{ base_python_package }}-psycopg2"
+  apt:
+    update_cache: "{{ update_apt_cache }}"
+    state: present
+    name:
+      - postgresql
+      - postgresql-contrib
+      - "{{ base_python_package }}-psycopg2"
   tags: packages
 
 - name: Ensure the PostgreSQL service is running

--- a/roles/rabbitmq/tasks/main.yml
+++ b/roles/rabbitmq/tasks/main.yml
@@ -10,9 +10,13 @@
                   state=present
 
 - name: Install RabbitMQ server
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
-  with_items:
-    - rabbitmq-server
+  apt:
+    update_cache: "{{ update_apt_cache }}"
+    state: present
+    name:
+      - rabbitmq-server
+  tags:
+    - packages
 
 - name: Enable the RabbitMQ Management Console
   rabbitmq_plugin: names=rabbitmq_management state=enabled

--- a/roles/web/tasks/install_additional_packages.yml
+++ b/roles/web/tasks/install_additional_packages.yml
@@ -7,9 +7,11 @@
   when: enable_deadsnakes_ppa
 
 - name: Install additional packages
-  apt: name={{ item }} update_cache={{ update_apt_cache }} state=present
-  with_items:
-    - libcurl4-gnutls-dev
-    - gnutls-dev
-    - libpq-dev
-    - "{{ virtualenv_python_version + '-dev' }}"
+  apt:
+    update_cache: "{{ update_apt_cache }}"
+    state: present
+    name:
+      - libcurl4-gnutls-dev
+      - gnutls-dev
+      - libpq-dev
+      - "{{ virtualenv_python_version + '-dev' }}"

--- a/roles/web/tasks/setup_virtualenv.yml
+++ b/roles/web/tasks/setup_virtualenv.yml
@@ -26,10 +26,11 @@
            creates={{ virtualenv_path }}/bin/activate
 
 - name: Ensure gunicorn and pycurl are installed in the virtualenv
-  pip: virtualenv={{ virtualenv_path }} name={{ item }}
-  with_items:
-    - gunicorn
-    - pycurl
+  pip:
+    virtualenv: "{{ virtualenv_path }}"
+    name:
+      - gunicorn
+      - pycurl
 
 - name: Create the Gunicorn script file
   template: src=gunicorn_start.j2


### PR DESCRIPTION
This behavior was [deprecated in Ansible 2.7](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions).

The behavior we use here instead has been available since Ansible 2.3.

This resolves the deprecation warnings in the [most recent build](https://travis-ci.org/jcalazan/ansible-django-stack/builds/468778606):
> [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: ['libcurl4-gnutls-dev',
'gnutls-dev', 'libpq-dev', u"{{ virtualenv_python_version + '-dev' }}"]` and
remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.