### PR TITLE
Block invalid host header

### DIFF
--- a/roles/nginx/templates/youtubeadl.j2
+++ b/roles/nginx/templates/youtubeadl.j2
@@ -7,6 +7,13 @@ upstream {{ application_name }}_wsgi_server {
 }
 
 server {
+    listen        80 default_server;
+    server_name   _;
+    server_tokens off;
+    return        444;
+}
+
+server {
     listen      80;
     server_name {{ nginx_server_name }};
     rewrite     ^ https://$server_name$request_uri? permanent;


### PR DESCRIPTION
Invalid host headers will reach the Django application, throwing an error, cluttering logs, posing possible security risks without rejection at the Nginx level.

This also appears to prevent 400s returned by Nginx when the host header is blank from leaking the Nginx version and OS. Try `curl 'http://<server_name>/' -H Host: '` and should see something like this:
```
<html>
<head><title>400 Bad Request</title></head>
<body bgcolor="white">
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
```

Should be able to see errors thrown in application with `curl 'http://<server_name>/' -H 'Host: example.com'`. With this PR, the response should be `curl: (52) Empty reply from server`.

See: https://nginx.org/en/docs/http/request_processing.html#how_to_prevent_undefined_server_names