### PR TITLE
Upgrade base image to Bionic Beaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Environment-specific settings are in the `env_vars` directory.
 A `certbot` role is also included for automatically generating and renewing
 trusted SSL certificates with [Let's Encrypt][lets-encrypt].
 
-**Tested with OS:** Ubuntu 16.04 LTS (64-bit PC), Ubuntu 14.04 LTS (64-bit PC)
+**Tested with OS:** Ubuntu 18.04 LTS (64-bit), Ubuntu 16.04 LTS (64-bit).
 
 **Tested with Cloud Providers:** [Digital Ocean][digital-ocean], [AWS][aws], [Rackspace][rackspace]
 
@@ -46,7 +46,7 @@ When choosing an Ansible version, consider:
   (currently, Molecule requires Ansible 2.4 or later)
 
 Ansible has been configured to use Python 3 inside the remote machine when
-provisioning it. In Ubuntu 14.04/16.04 LTS, compatible Ansible versions are not
+provisioning it. In Ubuntu 16.04 LTS, compatible Ansible versions are not
 in the main package repositories, but can be installed from the Ansible PPA by
 running these commands:
 
@@ -317,14 +317,9 @@ to run during deployment in most Django environments.
 
 ### Changing the Ubuntu release
 
-The [Vagrantfile](Vagrantfile) uses the Ubuntu 16.04 LTS Vagrant box for a
+The [Vagrantfile](Vagrantfile) uses the Ubuntu 18.04 LTS Vagrant box for a
 64-bit PC that is published by Canonical in HashiCorp Atlas. To use Ubuntu
-14.04 LTS instead, change the `config.vm.box` setting to `ubuntu/trusty64`. To
-use the Vagrant box for a 32-bit PC, change this setting to `ubuntu/xenial32`
-or `ubuntu/trusty32`.
-
-Note that the included configuration for Docker is not written to work with
-Ubuntu 14.04 LTS.
+16.04 LTS instead, change the `config.vm.box` setting to `ubuntu/xenial64`.
 
 ### Changing the Python version used by your application
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,12 +5,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   config.ssh.forward_agent = false
-
   config.vm.define "my-cool-app.local", primary: true do |app|
     app.vm.hostname = "my-cool-app"
-
     app.vm.network "private_network", type: "dhcp"
   end
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Ubuntu 16.04 base image from the Docker repository
-FROM ubuntu:xenial
+# Use the official Ubuntu 18.04 base image from the Docker repository
+FROM ubuntu:bionic
 
 # Allow processes to detect that they are being run in a container
 ENV container oci

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,11 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: instance
+  - name: instance-bionic
+    image: ubuntu
+    image_version: bionic
+    privileged: true
+  - name: instance-xenial
     image: ubuntu
     image_version: xenial
     privileged: true


### PR DESCRIPTION
- Ubuntu 14.04 is rapidly approaching EOL (April, 2019).
- Python 2 will no longer be supported in one year's time (Jan, 2020)

In this day and age, nobody should really be running infrastructure on
32-bit machines.

Update the README to refer to 18.04 as the default image, with 16.04
supported as well. Python 3 is the default version as well - Python 2
can still be supported, but anybody starting out with this repo likely
will not be deploying Python 2: tune instructions to assume that 18.04
with Python 3 is the default starting point for everyone.