### PR TITLE
[DO NOT MERGE UNTIL TESTS PASS] Remove molecule-notest tag.

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,12 @@
     - name: Install Python3
       raw: apt-get install python3-minimal
       changed_when: false
+      # Update IPV6tables due to ufw bug. See issue #128 and PR #129.
+      # https://github.com/husarnet/docker-example/issues/1#issuecomment-767833378
+      # TODO: Remove this for a future Ubuntu release that solves the bug.
+    - name: Update IPV6tables
+      raw: update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
+      changed_when: false
 
   module_defaults:
     apt:

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -14,8 +14,6 @@
 
 - include: setup_uncomplicated_firewall.yml
   when: enable_ufw is defined and enable_ufw
-  # TODO: Re-enable this test when we figure out how to integrate ipv6 support with GitHub Actions.
-  tags: molecule-notest
 
 - include: setup_fail2ban.yml
   when: enable_fail2ban is defined and enable_fail2ban


### PR DESCRIPTION
Adding this PR so that we can periodically check whether the TravisCI build is working with IPV6.

The test was skipped via #128 due to failing tests, because TravisCI isn't properly handling IPV6 for our uncomplicated firewall implementation.