### PR TITLE
Express ports as strings to silence warning

### DIFF
--- a/roles/security/vars/main.yml
+++ b/roles/security/vars/main.yml
@@ -3,8 +3,8 @@ user_public_keys:
   - ~/.ssh/id_rsa.pub
 
 ufw_allowed_ports:
-  - 22
-  - 80
-  - 443
+  - '22'
+  - '80'
+  - '443'
 
 shell: "/bin/bash"


### PR DESCRIPTION
Without this change, running `vagrant up` (with the `security` role) on
Ansible 2.8 will give warnings:

     [WARNING]: The value 22 (type int) in a string field was converted to '22'
    (type string). If this does not look like what you expect, quote the entire
    value to ensure it does not change.

     [WARNING]: The value 80 (type int) in a string field was converted to '80'
    (type string). If this does not look like what you expect, quote the entire
    value to ensure it does not change.

     [WARNING]: The value 443 (type int) in a string field was converted to '443'
    (type string). If this does not look like what you expect, quote the entire
    value to ensure it does not change.