### PR TITLE
Force `apt-get` use, since aptitude is deprecated

### DIFF
--- a/dbservers.yml
+++ b/dbservers.yml
@@ -11,6 +11,10 @@
     - env_vars/base.yml
     - env_vars/{{ env }}.yml
 
+  module_defaults:
+    apt:
+      force_apt_get: true
+
   roles:
     - base
     - db

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -23,6 +23,10 @@
       raw: apt-get install python3-minimal
       changed_when: false
 
+  module_defaults:
+    apt:
+      force_apt_get: true
+
   roles:
     - security
     - base

--- a/security.yml
+++ b/security.yml
@@ -11,6 +11,9 @@
     - env_vars/base.yml
     - env_vars/{{ env }}.yml
     - roles/base/defaults/main.yml
+  module_defaults:
+    apt:
+      force_apt_get: true
 
   roles:
     - security

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -10,6 +10,9 @@
   vars_files:
     - env_vars/base.yml
     - env_vars/vagrant.yml
+  module_defaults:
+    apt:
+      force_apt_get: true
 
   roles:
     - base

--- a/webservers.yml
+++ b/webservers.yml
@@ -10,6 +10,9 @@
   vars_files:
     - env_vars/base.yml
     - env_vars/{{ env }}.yml
+  module_defaults:
+    apt:
+      force_apt_get: true
 
   roles:
     - base


### PR DESCRIPTION
On Ansible 2.8, any step using `apt:` will give a warning:

> [WARNING]: Could not find aptitude. Using apt-get instead

So, do as the warning says and force use of `apt-get`.
This can be done by explicitly adding `force_apt_get: true` beneath each
`apt:` block. However, we can instead enforce this by default at the
module level.

See: https://github.com/ansible/ansible/issues/56832