### PR TITLE
Upgrade Ansible to 2.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
 docker==3.6.0
-molecule==2.19.0
+molecule==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.7.12
+ansible==2.8.4


### PR DESCRIPTION
Per Ansible's release cycle, 2.7 is no long receiving "critical bug
fixes." Once 2.10 is released, 2.7 will cease to receive security fixes.

> Ansible maintenance continues for 3 releases. Thus the latest Ansible
> release receives security and general bug fixes when it is first
> released, security and critical bug fixes when the next Ansible
> version is released, and only security fixes once the follow on to
> that version is released.

https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#release-status

-------

Merging this PR as-is will introduce a few new warnings (though the warnings do not break build functionality). Those warnings are addressed in separate PRs:
- https://github.com/jcalazan/ansible-django-stack/pull/131
- https://github.com/jcalazan/ansible-django-stack/pull/132