### PR TITLE
Update documentation for supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ A quick way to get started is with Vagrant.
 - [VirtualBox][virtual-box_downloads] or [Docker][docker-get_started]
 
 It's recommended to use the version of Ansible specified in `requirements.txt`,
-although any version greater than Ansible 2.4 will work with this repository.
+although any version greater than Ansible 2.7 will work with this repository.
 When choosing an Ansible version, consider:
 
 - Ansible only issues security fixes for the [last three major releases][ansible-release_cycle].
 - The included version of `molecule` has requirements on the Ansible version
-  (currently, Molecule requires Ansible 2.4 or later)
+  (currently, Molecule requires Ansible 2.5 or later and the 2.23 release
+  will require Ansible 2.7 or greater)
 
 Ansible has been configured to use Python 3 inside the remote machine when
 provisioning it. In Ubuntu 16.04 LTS, compatible Ansible versions are not

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -13,13 +13,7 @@ Requirements
 Install
 =======
 
-Ansible < 2.6
-
-.. code-block:: bash
-
-    $ sudo pip install docker-py
-
-Ansible >= 2.6
+(Running `pip install -r requirements-dev.txt` will cover this)
 
 .. code-block:: bash
 


### PR DESCRIPTION
The installed release of molecule (2.22) requires Ansible 2.5 or greater:

> ### Requirements
> ...
> Python 2.7 or Python >= 3.5 with Ansible >= 2.5

https://molecule.readthedocs.io/en/2.22/installation.html

------------------------------------------------------------------------

The next release of Molecule (2.23) will require Ansible 2.7 or greater:

> Supported Ansible versions are now 2.9, 2.8, 2.7

https://github.com/ansible/molecule/blob/master/CHANGELOG.rst