### PR TITLE
Upgrade to Ansible 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ molecule test
 [youtube-audio-dl]: https://github.com/jcalazan/youtube-audio-dl
 [ansible-installation_guide]: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html
 [ansible-best_practices]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html
-[ansible-release_cycle]: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html?highlight=release
+[ansible-release_cycle]: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html
 [docker-get_started]: https://www.docker.com/get-started
 [lets-encrypt]: https://letsencrypt.org/
 [vagrant-downloads]: https://www.vagrantup.com/downloads.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.8.4
+ansible==2.9.2


### PR DESCRIPTION
At time of writing, Ansible 2.9 is the [most recent stable release][cycle].

It is maintained with both security and general bug fixes. When 2.10 is released, 2.8 will cease to receive critical bug fixes (only getting security fixes). Get ahead of that process now by upgrading to Ansible 2.9.

No deprecation warnings were observed as part of this upgrade!

[cycle]: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html