### PR TITLE
Load Vagrant keypair from official repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo ope
 RUN adduser --disabled-password --gecos "" vagrant
 
 # Allow the "vagrant" user to login via SSH using the insecure keypair
-RUN su -c "URL=https://github.com/mitchellh/vagrant/raw/master/keys/%s.pub ssh-import-id vagrant" vagrant
+RUN su -c "URL=https://github.com/hashicorp/vagrant/raw/master/keys/%s.pub ssh-import-id vagrant" vagrant
 
 # Grant password-less sudo privileges to the "vagrant" user
 RUN echo "vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant


### PR DESCRIPTION
The vagrant repo has moved from `mitchellh` to the `hashicorp` organization. Update the URL.