### PR TITLE
Replace double quotes to single quotes in virtualenv_postactivate.j2

### DIFF
--- a/roles/web/templates/virtualenv_postactivate.j2
+++ b/roles/web/templates/virtualenv_postactivate.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 {% for variable_name, value in django_environment.items() %}
-export {{ variable_name }}='{{ value }}'
+export {{ variable_name }}={{ value | quote }}
 {% endfor %}

--- a/roles/web/templates/virtualenv_postactivate.j2
+++ b/roles/web/templates/virtualenv_postactivate.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 {% for variable_name, value in django_environment.items() %}
-export {{ variable_name }}="{{ value }}"
+export {{ variable_name }}='{{ value }}'
 {% endfor %}


### PR DESCRIPTION
Replace double quotes to single quotes in virtualenv_postactivate.j2 in order to reduce bad ecaping of special characters in `postactivate` shell script.