### PR TITLE
Reference normal requirements / Readme enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,29 @@ sudo apt-get update
 The main settings to change are in the [`env_vars/base.yml`](env_vars/base.yml)
 file, where you can configure the location of your Git project, the project
 name, and the application name which will be used throughout the Ansible
-configuration. I set some default values based on my open-source app, [YouTube
+configuration. 
+
+#### Required changes from default project
+I set some default values based on my open-source app, [YouTube
 Audio Downloader][youtube-audio-dl].
 
+In `base.uml` update the following configuration variables:
+ - `git_repo`
+ - `project_name`
+ - `application_name`
+  
+Rename the nginx template file:
+In roles/nginx/templates/, rename:
+`youtubeadl.j2` to the `project_name` you set in `base.yml` above.
+
+See *Pulling from a private git repository using SSH agent forwarding* below 
+for info on using a git repository via ssh.
+
+The project uses `master` branch of the `git_repo` repositoy by default. 
+Specify a different branch using `git_branch` in `vagrant.yml`. 
+
+
+#### Project Structure
 Note that the default values in the playbooks assume that your project
 structure looks something like this:
 

--- a/env_vars/vagrant.yml
+++ b/env_vars/vagrant.yml
@@ -44,7 +44,7 @@ django_secret_key: "akr2icmg1n8%z^3fe3c+)5d0(t^cy-2_25rrl35a7@!scna^1#"
 
 broker_url: "amqp://{{ rabbitmq_application_user }}:{{ rabbitmq_application_password }}@localhost/{{ rabbitmq_application_vhost }}"
 
-requirements_file: "{{ project_path }}/requirements_local.txt"
+requirements_file: "{{ project_path }}/requirements.txt"
 
 run_django_db_migrations: true
 run_django_collectstatic: true


### PR DESCRIPTION
This PR helps increase likelihood of getting to stated 5 minutes to joy:

 - `readme.md`
   - Specific variable and file name changes needed to more quickly get to joy from the default settings
   - A note on where to specify repo branch setting

     These changes are useful for someone kicking the tires on this stack. For example, you have an existing django project and need to make minor tweaks for to use this playbook. You push a branch i.e.  `ads-test` and want to use this instead of master. Also, captures missing note about need to rename the nginx template file.

 - `env_vars/vagrant.yml`
  Changed `requirements_file` to match the name given in the readme's project organization.  This still works with youtube-audio-dl as it [relies](https://github.com/jcalazan/youtube-audio-dl/blob/master/requirements.txt) on `requirements.txt`. 

I think someone who has more experience using playbooks might realize these changes are necessary. However, if you're dabbling in this advanced devops setup, these extra bumpers might make it easier for someone to try out.