### PR TITLE
Control PostgreSQL installed version with 'db_version' variable

### DIFF
--- a/env_vars/development.yml
+++ b/env_vars/development.yml
@@ -9,6 +9,7 @@ git_branch: development
 db_user: "{{ application_name }}"
 db_name: "{{ application_name }}"
 db_password: password
+db_version: 12
 
 
 # Gunicorn settings. For the number of workers, a good rule to follow is

--- a/env_vars/vagrant.yml
+++ b/env_vars/vagrant.yml
@@ -9,6 +9,7 @@ git_branch: master
 db_user: "{{ application_name }}"
 db_name: "{{ application_name }}"
 db_password: password
+db_version: 12
 
 
 # Gunicorn settings. For the number of workers, a good rule to follow is

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -17,8 +17,8 @@
     update_cache: "{{ update_apt_cache }}"
     state: present
     name:
-      - postgresql
-      - postgresql-contrib
+      - "postgresql-{{ db_version }}"
+      - "postgresql-contrib-{{ db_version }}"
       - "{{ base_python_package }}-psycopg2"
   tags: packages
 


### PR DESCRIPTION
Version 12 is used in the playbook
Closes #168
Note: PostgreSQL version is managed with 'db_version' variable. However, there is no DB upgrade process with DB previous code deletion, DB stopped and restarted. This is not an issue compared to playbook version without this commit though.