### PR TITLE
Upgrade to Ubuntu 20.04 LTS (Focal Fossa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ to run during deployment in most Django environments.
 
 ### Changing the Ubuntu release
 
-The [Vagrantfile](Vagrantfile) uses the Ubuntu 18.04 LTS Vagrant box for a
+The [Vagrantfile](Vagrantfile) uses the Ubuntu 20.04 LTS Vagrant box for a
 64-bit PC that is published by Canonical in HashiCorp Atlas. To use Ubuntu
-16.04 LTS instead, change the `config.vm.box` setting to `ubuntu/xenial64`.
+18.04 LTS instead, change the `config.vm.box` setting to `ubuntu/bionic64`.
 
 ### Changing the Python version used by your application
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.ssh.forward_agent = false
   config.vm.define "my-cool-app.local", primary: true do |app|
     app.vm.hostname = "my-cool-app"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Ubuntu 18.04 base image from the Docker repository
-FROM ubuntu:bionic
+# Use the official Ubuntu 20.04 base image from the Docker repository
+FROM ubuntu:focal
 
 # Allow processes to detect that they are being run in a container
 ENV container oci

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,13 +6,13 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: instance-bionic
-    image: ubuntu
-    image_version: bionic
-    privileged: true
   - name: instance-xenial
     image: ubuntu
     image_version: xenial
+    privileged: true
+  - name: instance-focal
+    image: ubuntu
+    image_version: focal
     privileged: true
 provisioner:
   name: ansible

--- a/roles/certbot/defaults/main.yml
+++ b/roles/certbot/defaults/main.yml
@@ -2,5 +2,5 @@
 
 certbot_auto_renew: true
 certbot_admin_email: admin@example.com
-certbot_script: /opt/certbot-auto
+certbot_script: /usr/bin/certbot
 certbot_output_dir: "/etc/letsencrypt/live/{{ inventory_hostname }}"

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
-- name: Download certbot
-  get_url: url=https://dl.eff.org/certbot-auto dest={{ certbot_script }} mode=0755
+- name: Install Certbot
+  apt:
+    update_cache: "{{ update_apt_cache }}"
+    state: present
+    name:
+      - certbot
+      - python3-certbot-nginx
+  tags: packages
 
 - name: Check if Nginx exists
   stat: path=/etc/init.d/nginx


### PR DESCRIPTION
In addition to upgrading vagrant, docker and molecule to use the latest
LTS release there are two other factors which promted the upgrade:

1. certbot-auto cannot be installed on 20.04 LTS as the python-virtual
   package is no longer available with the upgrade to python3.

2. The release of certbot 1.9.0 (2020-10-06) deprecates certbot-auto:
   https://community.letsencrypt.org/t/certbot-1-9-0-release/135414

The certbot package, provided by Canonical now replaces certbot-auto. It
was tested on a DigitalOcean droplet freshly re-built with 18.04 LTS and
20.04 LTS with no issues.