### PR TITLE
Restart celery after any changes to the code

### DIFF
--- a/roles/web/tasks/setup_django_app.yml
+++ b/roles/web/tasks/setup_django_app.yml
@@ -31,5 +31,7 @@
     settings: "{{ django_settings_file }}"
   environment: "{{ django_environment }}"
   when: run_django_collectstatic is defined and run_django_collectstatic
-  notify: restart application
+  notify:
+    - restart application
+    - restart celery
   tags: django.collectstatic

--- a/roles/web/tasks/setup_git_repo.yml
+++ b/roles/web/tasks/setup_git_repo.yml
@@ -34,7 +34,9 @@
        dest={{ project_path }}
        accept_hostkey=yes
   when: setup_git_repo is defined and setup_git_repo
-  notify: restart application
+  notify:
+    - restart application
+    - restart celery
   tags: git
 
 - name: Delete all .pyc files

--- a/roles/web/tasks/setup_virtualenv.yml
+++ b/roles/web/tasks/setup_virtualenv.yml
@@ -75,7 +75,9 @@
             group={{ gunicorn_group }}
             mode=0640
             backup=yes
-  notify: restart application
+  notify:
+    - restart application
+    - restart celery
   tags: deploy
 
 - name: Create the maintenance page


### PR DESCRIPTION
Ensure that any celery workers are restarted so that they pick up and changes to the code after a deploy.

This pull request is dependent on the changes in https://github.com/YPCrumble/django-default-project/pull/2 which add celery to the django default project so the molecule tests pass.