### PR TITLE
Stop invalid host header errors being raised by Django

### DIFF
--- a/roles/nginx/templates/django_default_project.j2
+++ b/roles/nginx/templates/django_default_project.j2
@@ -10,6 +10,14 @@ server {
     listen      80;
     server_name {{ nginx_server_name }};
     server_tokens off;
+
+    # Terminate the request immediately if a request uses the IP address.
+    # This stops Invalid HTTP_HOST header exceptions being raised by Django.
+
+    if ($host !~* ^({{ nginx_server_name }})$ ) {
+        return 444;
+    }
+
     return 301  https://$server_name$request_uri;
 }
 
@@ -30,6 +38,13 @@ server {
     {% if nginx_strong_dh_group %}
     ssl_dhparam          /etc/ssl/certs/dhparams.pem;
     {% endif %}
+
+    # Terminate the request immediately if a request uses the IP address.
+    # This stops Invalid HTTP_HOST header exceptions being raised by Django.
+
+    if ($host !~* ^({{ nginx_server_name }})$ ) {
+        return 444;
+    }
 
     # Prevent MIME type sniffing for security
     add_header X-Content-Type-Options "nosniff";
@@ -95,7 +110,7 @@ server {
 
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_redirect off;
 
         # Try to serve static files from nginx, no point in making an


### PR DESCRIPTION
When a client uses the IP address instead of the domain name Django will
raise an `Invalid HTTP_HOST header` error since the IP address is not
listed in the ALLOWED_HOSTS setting.

This situation occurs most commonly with bots probing the site for security
holes. If you log Django errors using Sentry then a constant stream of these
errors will be reported. At best they are a distraction.

The solution is for nginx to terminate the connection immediately so the
request never reaches Django. This is done simply by matching the host
header with the sites IP address and raising the HTTP error 444 which is
unique to nginx and instructs the server to close the connection immediately.
Nothing is returned to the client so it effectively gets a status code of 0.

The problem and the solution is described clearly in the following post:
https://www.borfast.com/blog/2020/07/06/invalid-http_host-header-errors-in-django-and-nginx/

There a related problem that triggers same Invalid HTTP_HOST header error
when the client does not set the HOST header at all. This is discussed and
a solution given in this Stack Overflow question (the URL was truncated
but is still valid) https://stackoverflow.com/questions/25370868/

The test for using an IP address instead of a domain name was added to post
80 and 443. It should have been possible to let the redirect from HTTP to
HTTPS complete and have test in a single location however since the intent
of the client is generally malicious it didn't seem right to waste more
energy than was necessary, hence the duplication of the check.