### PR TITLE
Fix the logs directory permissions

### DIFF
--- a/roles/celery/tasks/setup_supervisor.yml
+++ b/roles/celery/tasks/setup_supervisor.yml
@@ -21,7 +21,7 @@
     owner: "{{ celery_user }}"
     group: "{{ celery_group }}"
     state: directory
-    mode: "0774"
+    mode: "0664"
   changed_when: false
 
 - name: Check for an existing celery logfile

--- a/roles/celery/tasks/setup_supervisor.yml
+++ b/roles/celery/tasks/setup_supervisor.yml
@@ -21,7 +21,7 @@
     owner: "{{ celery_user }}"
     group: "{{ celery_group }}"
     state: directory
-    mode: "0644"
+    mode: "0774"
   changed_when: false
 
 - name: Check for an existing celery logfile

--- a/roles/web/tasks/setup_virtualenv.yml
+++ b/roles/web/tasks/setup_virtualenv.yml
@@ -48,7 +48,7 @@
     path: "{{ application_log_dir }}"
     owner: "{{ gunicorn_user }}"
     group: "{{ gunicorn_group }}"
-    mode: "0774"
+    mode: "0664"
     state: directory
   changed_when: false
 


### PR DESCRIPTION
Hi,

This PR is used for fixing the celery logs directory permissions.

This directory (`celery_log_dir`) is our application log directory:
- `application_log_dir`: https://github.com/jcalazan/ansible-django-stack/blob/master/roles/web/defaults/main.yml#L12
- `celery_log_dir`: https://github.com/jcalazan/ansible-django-stack/blob/master/roles/celery/vars/main.yml#L15

But we should set "774" permissions to `application_log_dir`: (https://github.com/jcalazan/ansible-django-stack/blob/master/roles/web/tasks/setup_virtualenv.yml#L46)

So adding "0644" to this directory causes the deployment to fail because the application does not have permission to work with the application log file.

Please help me to review and merge, thanks!