### PR TITLE
Fix application log directory mode (0664 → 0774)

### DIFF
--- a/roles/web/tasks/setup_virtualenv.yml
+++ b/roles/web/tasks/setup_virtualenv.yml
@@ -67,7 +67,7 @@
     path: "{{ application_log_dir }}"
     owner: "{{ gunicorn_user }}"
     group: "{{ gunicorn_group }}"
-    mode: "0664"
+    mode: "0774"
     state: directory
   changed_when: false
 


### PR DESCRIPTION
## Summary
- Fix the application log directory mode from `0664` to `0774` in `setup_virtualenv.yml`
- Directories need the execute bit to be traversable — without it, non-root users get `PermissionError` when Django tries to configure file logging, causing gunicorn workers to crash on startup

## Why this doesn't fail in CI
Molecule tests run as root inside Docker containers. Root ignores directory permission bits entirely, so the missing execute bit never causes a failure.

## Test plan
- [ ] Deploy to a server with a non-root application user and verify gunicorn starts without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)